### PR TITLE
Added a seed_free function to allow the user to delete gpurandstate if it is no lnger necessary

### DIFF
--- a/libraries/plumbing/backend_gpu/defs.h
+++ b/libraries/plumbing/backend_gpu/defs.h
@@ -137,6 +137,11 @@ namespace hila {
 void seed_device_rng(unsigned long long seed);
 } // namespace hila
 
+namespace hila {
+// should this be __device__ __host__ here?
+void free_seed();
+} // namespace hila
+
 #define GPU_CHECK(cmd)                                                                 \
     do {                                                                               \
         auto code = cmd;                                                               \
@@ -164,6 +169,10 @@ inline void synchronize_threads() {
 namespace hila {
 // double random();  // defined in random.h
 void seed_device_rng(unsigned long long seed);
+} // namespace hila
+
+namespace hila {
+void free_seed();
 } // namespace hila
 
 using gpuError = int;

--- a/libraries/plumbing/backend_gpu/hila_gpu.cpp
+++ b/libraries/plumbing/backend_gpu/hila_gpu.cpp
@@ -82,6 +82,10 @@ void hila::seed_device_rng(unsigned long long seed) {
     check_device_error("seed_random kernel");
 }
 
+void hila::free_seed(){
+	gpuFree(gpurandstate);
+}
+
 /* Generate random numbers on device or host */
 __device__ __host__ double hila::random() {
 #ifdef __GPU_DEVICE_COMPILE__


### PR DESCRIPTION
Note that this doesn't prevent the user from calling random after seed_free. Should we make it more fault-tolerant?