### PR TITLE
To master: refine and edit documentation in random.h/.cpp

### DIFF
--- a/docs/guide/user_guide/field.dox
+++ b/docs/guide/user_guide/field.dox
@@ -2,7 +2,7 @@
 /**
 \page field_documentation Field
 
-Field is the most important Datatype offered by HILA. The Field is a container of lattice fields, and is the general object we evolve and iterate over. The Field can be comprised of either [Standard types](#standard) or [Basic types](#basic) listed above.
+Field is the most important Datatype offered by HILA. The Field is a container of lattice fields, and is the general object we evolve and iterate over. The Field can be comprised of either [Standard types](#standard) or [Basic types](#basic) listed on the [datatypes](#datatypes) page.
 
 To see all the possible methods of a Field see the class page which lists comprehensive documentation.
 
@@ -88,15 +88,55 @@ onsites(ALL) {
 }
 ~~~
 
+## External variables
+
+Assignment and manipulation of variables defined outside of onsites loops are illustrated below:
+~~~cpp
+    double a = 3, b = 5;
+    Field<double> f, g=0;
+
+    onsites(ALL) {
+        f[X] = (a + b);            // ok, loop extern variables a,b do not change within the loop
+        b = f[X];                  // ERROR: cannot change a loop external non-field variable (except reductions)
+        double c = sin(f[X]);      // ok, variable c defined within the loop
+        f[X] = c + g;              // ERROR: using field variable g without [X]
+    }
+~~~
+
+## Accessing field elements outside of loop
+
+There are a few ways of accessing Field elements which exclusively are to be used outside of onsites loops.
+
+* **Access field at a single point:**
+
+~~~cpp
+  CoordinateVector v = {2,3,4,5};
+  auto value = f[v];              // "value" is broadcast to all nodes!
+  f[v] = 1;                       // In assignment, values are not broadcast: the node which
+                                  // owns site v must have correct rhs.
+~~~
+
+* **Accessing multiple elements:**
+
+This is done by using Field::get_elements and Field::set_elements which take in a std::vector of coordinates.
+
+~~~cpp
+    std::vector<CoordinateVector> coordinates = {{2,3,4,5}, {1,3,4,5}}; // 4 Dimensional field
+    std::vector<MyType> values = f.get_elements(coordinates); // Returns std::vector of elements that were fetched
+    g.set_elements(values, coordinates); // Sets values fetched from f
+~~~
+
+Additionally Field::get_elements takes in an additional argument broadcast `get_elements(coordinates, broadcast)`. If set to true then the fetched elements are broadcasted to all MPI ranks, by default it is set to false.
+
 # Reductions
 
 ## Field reduction methods {#field_reduction_methods_guide}
 
 Reduction on a single Field variable can be done with functions:
-- `T Field<T>::sum()` : sum of all field elements. 
-- `T Field<T>::product()` : product of field elements.
-- `T Field<T>::min()` : minimum element
-- `T Field<T>::max()` : maximum
+- `T Field::sum()` : sum of all field elements. 
+- `T Field::product()` : product of field elements.
+- `T Field::min()` : minimum element
+- `T Field::max()` : maximum
 
 `sum()` and `product()` take optional arguments:
 `sum(Parity par = ALL)` or `sum(Parity par = ALL ,bool allreduce = true)`. Parity gives the parity of sites over which the reduction is done, and if allreduce = false the reduction result is only sent to rank 0. Defaults are parity=ALL and allreduce = true.  
@@ -223,7 +263,7 @@ The class `Reduction<T>` implements the following methods (see examples below):
 The first call of `value()` or `reduce()` must be called by all ranks, otherwise the program deadlocks. Subsequent calls to `value()` just return the previously reduced value.
 
 
-**Delayed reduction** means that the MPI reduction is delayed until the final result is desired:
+* **Delayed reduction** means that the MPI reduction is delayed until the final result is desired:
 ~~~cpp
     Field<Complex<double>> f[NDIM];
     ...
@@ -245,7 +285,7 @@ one (MPI) reduction operation, whereas the standard method (using `Complex<doubl
 The function `r.value()` must be called by all ranks or program deadlocks.
 The result of the reduction is not affected.
 
-**Non-blocking reduction** enables overlapping MPI communication and computation (implemented using `MPI_Ireduce()`).  This potentially gives higher performance.
+* **Non-blocking reduction** enables overlapping MPI communication and computation (implemented using `MPI_Ireduce()`).  This potentially gives higher performance.
 ~~~cpp
     Reduction<Complex<double>> r(0);
     r.nonblocking();
@@ -354,21 +394,7 @@ N fields G[N], where we know the field values are between 0 and fmax:
 > NOTE: ReductionVector indexing has no protection. Using index past the 
 > ends of the array will cause trouble!
 
-
-## Other features
-
-Assignment and manipulation of external variables are illustrated below:
-~~~cpp
-    double a = 3, b = 5;
-    Field<double> f, g=0;
-
-    onsites(ALL) {
-        f[X] = (a + b);            // ok, loop extern variables a,b do not change within the loop
-        b = f[X];                  // ERROR: cannot change a loop extern non-field variable (except reductions)
-        double c = sin(f[X]);      // ok, variable c defined within the loop
-        f[X] = c + g;              // ERROR: using field variable g without [X]
-    }
-~~~
+# Shift operators
 
 Field::shift operations allow shifting all elements by a certain displacement vector v. Even and Odd elements cannot be shifted with Field::shift method
 ~~~cpp
@@ -381,13 +407,85 @@ Field::shift operations allow shifting all elements by a certain displacement ve
     f[EVEN] = g[X + v];            // Cannot be done with g.shift() alone
 ~~~
 
-Access field at a single point: `f[CoordinateVector]`.  This can be used only outside site loops.
+# Random number generators
+
+Random number generators are used with onsites loops. There are two random number generators available.
+
+* **Uniform distribution:**
 
 ~~~cpp
-  CoordinateVector v = {2,3,4,5};
-  auto value = f[v];              // "value" is broadcast to all nodes!
-  f[v] = 1;                       // In assignment, values are not broadcast: the node which
-                                  // owns site v must have correct rhs.
+Field<MyType> f;
+onsites(ALL) f[X].random();
 ~~~
+
+* **Gaussian distribution:**
+
+~~~cpp
+Field<MyType> f;
+onsites(ALL) f[X].gaussian_random();
+~~~
+
+# FFT
+
+# Mathematical methods {#mathematical_methods_field}
+
+Standard arithmetic methods:
+
+-  `Field::operator+`
+-  `Field::operator-`
+-  `Field::operator*`
+-  `Field::operator/`
+
+Arithmetic assignment methods:
+
+-  `Field::operator+=`
+-  `Field::operator-=`
+-  `Field::operator*=`
+-  `Field::operator/=`
+
+Mathematical functions:
+
+-  `Field::exp`
+-  `Field::log`
+-  `Field::sin`
+-  `Field::cos`
+-  `Field::tan`
+-  `Field::asin`
+-  `Field::acos`
+-  `Field::atan`
+-  `Field::abs`
+-  `Field::pow`
+-  `Field::squarenrom`
+-  `Field::norm`
+-  `Field::conj`
+-  `Field::dagger`
+-  `Field::real`
+-  `Field::imag`
+-  `Field::squarenorm_relative`
+
+Let `func` be a mathematical method defined above, then usage is:
+
+~~~cpp
+Field<MyType> f;
+f = func(f)
+~~~
+
+Additionally norm, conj, dagger, real and imag can be used as member functions `f.fun()`.
+Exceptions to this are pow and squarenorm_relative which take in additional arguments, see respective documentation for details.
+
+
+All mathematical functions are operated element wise on the Field using the definition of the element type T of the Field<T>:
+
+~~~cpp
+Field<R> res;
+onsites(ALL) {
+    res[X] = func(arg[X]);
+}
+return res;
+~~~
+
+if `func` is not defined for type T then an error is thrown.
+
+
 
 */

--- a/docs/guide/user_guide/user_guide.dox
+++ b/docs/guide/user_guide/user_guide.dox
@@ -7,6 +7,7 @@ This section is comprehensive description of the functionality HILA offers. For 
 
 - \subpage makefile
 - \subpage field_documentation
+
 - \subpage datatypes
 - \subpage input_library
 - \subpage test_input_and_layout

--- a/docs/ideas.md
+++ b/docs/ideas.md
@@ -1,0 +1,18 @@
+# Ideas for documentation
+
+## Datatypes
+
+- Each Datatype should list what it is assignment compatible with. 
+
+## Field
+
+- should we split field?
+
+- other features as own titles
+
+- add these:
+    - get slice 
+    - get_subvolume
+    - reflect
+    - mathematical operations
+    - gaussian_random?

--- a/libraries/plumbing/field.h
+++ b/libraries/plumbing/field.h
@@ -244,7 +244,7 @@ class Field {
 
     /**
      * @brief Field constructor
-     * @details The following ways of constructing a Field object are the following:
+     * @details The following ways of constructing a Field object are:
      *
      * __Default constructor__:
      *
@@ -278,7 +278,8 @@ class Field {
 
         // put here some implementation checks for field vars
 #ifdef VECTORIZED
-        static_assert(sizeof(hila::arithmetic_type<T>) == 4 || sizeof(hila::arithmetic_type<T>) == 8,
+        static_assert(sizeof(hila::arithmetic_type<T>) == 4 ||
+                          sizeof(hila::arithmetic_type<T>) == 8,
                       "In vectorized arch (e.g. AVX2), only 4 or 8 byte (32 or 64 bit) numbers for "
                       "Field<> implemented, sorry!");
 #endif
@@ -722,12 +723,6 @@ class Field {
 #endif
 
     /**
-     * @name Standard arithmetic operations
-     * @brief Not all are always callable, e.g. division may not be implemented by all field types
-     * since division is not defined for all @p Field::T types.
-     *  @{
-     */
-    /**
      * @brief Assignment operator.
      *
      * @details Assignment can be performed in the following ways:
@@ -1127,7 +1122,6 @@ class Field {
         f[ALL] = ::imag((*this)[X]);
         return f;
     }
-    /** @} */
 
     // Communication routines. These are all internal.
     dir_mask_t start_gather(Direction d, Parity p = ALL) const;
@@ -1742,6 +1736,22 @@ void swap(Field<T> &A, Field<T> &B) {
 ///////////////////////////////////////////////////////////////////////
 // Allow some arithmetic functions if implemented
 
+
+/**
+ * @name Mathematical methods.
+ * @tparam T Field element type of arg
+ * @tparam R Field return type
+ * @param arg input Field
+ * @return Field<R>
+ * @memberof Field
+ * @details See [field documentation](@ref mathematical_methods_field)
+ *
+ * @{
+ */
+
+/**
+ * @brief Exponential
+ */
 template <typename T, typename R = decltype(exp(std::declval<T>()))>
 Field<R> exp(const Field<T> &arg) {
     Field<R> res;
@@ -1751,6 +1761,9 @@ Field<R> exp(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Logarithm
+ */
 template <typename T, typename R = decltype(log(std::declval<T>()))>
 Field<R> log(const Field<T> &arg) {
     Field<R> res;
@@ -1760,6 +1773,9 @@ Field<R> log(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Sine
+ */
 template <typename T, typename R = decltype(sin(std::declval<T>()))>
 Field<R> sin(const Field<T> &arg) {
     Field<R> res;
@@ -1769,6 +1785,9 @@ Field<R> sin(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Cosine
+ */
 template <typename T, typename R = decltype(cos(std::declval<T>()))>
 Field<R> cos(const Field<T> &arg) {
     Field<R> res;
@@ -1778,6 +1797,9 @@ Field<R> cos(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Tangent
+ */
 template <typename T, typename R = decltype(tan(std::declval<T>()))>
 Field<R> tan(const Field<T> &arg) {
     Field<R> res;
@@ -1787,6 +1809,9 @@ Field<R> tan(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Arcsine
+ */
 template <typename T, typename R = decltype(asin(std::declval<T>()))>
 Field<R> asin(const Field<T> &arg) {
     Field<R> res;
@@ -1796,6 +1821,9 @@ Field<R> asin(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Arccosine
+ */
 template <typename T, typename R = decltype(acos(std::declval<T>()))>
 Field<R> acos(const Field<T> &arg) {
     Field<R> res;
@@ -1805,6 +1833,9 @@ Field<R> acos(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Arctangent
+ */
 template <typename T, typename R = decltype(atan(std::declval<T>()))>
 Field<R> atan(const Field<T> &arg) {
     Field<R> res;
@@ -1814,6 +1845,9 @@ Field<R> atan(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Absolute value
+ */
 template <typename T, typename R = decltype(abs(std::declval<T>()))>
 Field<R> abs(const Field<T> &arg) {
     Field<R> res;
@@ -1823,6 +1857,10 @@ Field<R> abs(const Field<T> &arg) {
     return res;
 }
 
+/**
+ * @brief Power
+ * @param p exponent to which Field element is raised to.
+ */
 template <typename T, typename P, typename R = decltype(pow(std::declval<T>()), std::declval<P>())>
 Field<R> pow(const Field<T> &arg, const P p) {
     Field<R> res;
@@ -1832,6 +1870,9 @@ Field<R> pow(const Field<T> &arg, const P p) {
     return res;
 }
 
+/**
+ * @brief Squared norm \f$|f|^2\f$
+ */
 template <typename T>
 double squarenorm(const Field<T> &arg) {
     double r = 0;
@@ -1840,6 +1881,7 @@ double squarenorm(const Field<T> &arg) {
     }
     return r;
 }
+
 
 template <typename T>
 double norm(const Field<T> &arg) {
@@ -1866,7 +1908,15 @@ Field<A> imag(const Field<T> &arg) {
     return arg.imag();
 }
 
-
+/**
+ * @brief Squarenorm relative \f$|a-b|^2\f$
+ *
+ * @tparam A Element type of Field a
+ * @tparam B Element type of Field b
+ * @param a Field a
+ * @param b Field b
+ * @return double
+ */
 template <typename A, typename B, typename R = decltype(std::declval<A>() - std::declval<B>())>
 double squarenorm_relative(const Field<A> &a, const Field<B> &b) {
     double res = 0;
@@ -1876,6 +1926,7 @@ double squarenorm_relative(const Field<A> &a, const Field<B> &b) {
     return res;
 }
 
+/// @}
 
 template <typename T>
 Field<T> Field<T>::shift(const CoordinateVector &v) const {

--- a/libraries/plumbing/random.cpp
+++ b/libraries/plumbing/random.cpp
@@ -36,13 +36,14 @@ double hila::host_random() {
 
 static bool rng_is_initialized = false;
 
-///
-/// Random shuffling of rng seed for MPI nodes
-/// Do it in a manner makes it difficult to give the same seed by mistake
-/// and also avoids giving the same seed for 2 nodes
-/// For single MPI node seed remains unchanged
-
 namespace hila {
+
+/**
+ * @brief Random shuffling of rng seed for MPI nodes.
+ * @details Do it in a manner makes it difficult to give the same seed by mistake
+ * and also avoids giving the same seed for 2 nodes
+ * For single MPI node seed remains unchanged
+ */
 uint64_t shuffle_rng_seed(uint64_t seed) {
 
     uint64_t n = hila::myrank();
@@ -53,6 +54,10 @@ uint64_t shuffle_rng_seed(uint64_t seed) {
 }
 
 
+/**
+ *@param seed unsigned int_64  
+ *@note On MPI, this function shuffles different seed values for all MPI ranks.  
+ */
 void initialize_host_rng(uint64_t seed) {
 
     seed = hila::shuffle_rng_seed(seed);
@@ -67,11 +72,17 @@ void initialize_host_rng(uint64_t seed) {
 
 } // namespace hila
 
-/// Seed random number generators
-/// Seed is shuffled so that different nodes
-/// get different rng seeds.  If seed == 0,
-/// generate seed using the time() -function.
 
+/**
+ *@details The optional 2nd argument indicates whether to initialize the RNG on GPU device:
+ * `hila::device_rng_on` (default) or `hila::device_rng_off`.  This argument does nothing if no GPU
+ * platform.  If `hila::device_rng_off` is used, `onsites()` -loops cannot contain random number calls
+ * (Runtime error will be flagged and program exits).
+ * 
+ * Seed is shuffled so that different nodes
+ * get different rng seeds.  If `seed == 0`,
+ * seed is generated through using the `time()` -function.
+ */  
 void hila::seed_random(uint64_t seed, bool device_init) {
 
     rng_is_initialized = true;
@@ -134,29 +145,32 @@ void hila::seed_random(uint64_t seed, bool device_init) {
 }
 
 ////////////////////////////////////////////////////////////////////
-/// Def here gpu rng functions for non-gpu
+// Def here gpu rng functions for non-gpu
 ////////////////////////////////////////////////////////////////////
 
 #if !(defined(CUDA) || defined(HIP))
 
+/**
+ *@details `hila::random()` does not work inside `onsites()` after this, 
+ *unless seeded again using `initialize_device_rng()`. Frees the memory RNG takes on the device. 
+ */  
 void hila::free_device_rng() {}
+
+/**
+ *@details Returns `true` on non-GPU archs.
+ */
 bool hila::is_device_rng_on() {
     return true;
 }
+
+/**
+ *@details This function shuffles the seed for different MPI ranks on MPI.  Called by `seed_random()` unless its 2nd
+ *argument is `hila::device_rng_off`. This can reinitialize device RNG free'd by `free_device_rng()`.
+ */
 void hila::initialize_device_rng(uint64_t seed) {}
 
 #endif
 
-
-///////////////////////////////////////////////////////////////////
-/// gaussian rng generation routines
-/// By default these give random numbers with variance 1.0, i.e.
-/// probability distribution is
-///           exp( -x*x/2 ), so < x^2 > = 1
-/// If you want random numbers with variance sigma, multiply the
-/// result by  sqrt(sigma):
-///       sqrt(sigma) * gaussrand();
-////////////////////////////////////////////////////////////////////
 
 #define VARIANCE 1.0
 
@@ -177,6 +191,24 @@ double hila::gaussrand2(double &out2) {
 
 #if !defined(CUDA) && !defined(HIP)
 
+/**
+ * @details By default these gives random numbers with variance \f$1.0\f$ and expectation value \f$0.0\f$, i.e.
+ * \f[
+ *    e^{-(\frac{x^{2}}{2})}
+ * \f]
+ * with variance
+ * \f[
+ *    < x^{2}-0.0> = 1
+ * \f] 
+ *
+ * If you want random numbers with variance \f$ \sigma^{2} \f$, multiply the
+ * result by \f$ \sqrt{\sigma^{2}} \f$ i.e.,
+ * \code {.cpp}
+ *       sqrt(sigma * sigma) * gaussrand();
+ * \endcode
+ *
+ * @return double
+ */  
 double hila::gaussrand() {
     static double second;
     static bool draw_new = true;
@@ -201,19 +233,22 @@ double hila::gaussrand() {
 
 #endif
 
-///////////////////////////////////////////////////////////////
-/// Check if RNG is seeded already
-///////////////////////////////////////////////////////////////
-
+/**
+ *@returns bool
+ */
 bool hila::is_rng_seeded() {
     return rng_is_initialized;
 }
 
 
 ///////////////////////////////////////////////////////////////
-/// RNG initialization check - emitted on loops
+// RNG initialization check - emitted on loops
 ///////////////////////////////////////////////////////////////
 
+/**
+ *@details program quits with error message if RNG is not initialized.
+ *It also quit with error messages if the device RNG is not initialized.
+ */
 void hila::check_that_rng_is_initialized() {
     bool isinit;
 
@@ -231,3 +266,9 @@ void hila::check_that_rng_is_initialized() {
     }
 #endif
 }
+
+
+
+
+
+

--- a/libraries/plumbing/random.h
+++ b/libraries/plumbing/random.h
@@ -6,42 +6,40 @@ namespace hila {
 constexpr bool device_rng_off = false;
 constexpr bool device_rng_on = true;
 
-/// Seed random generators with 64-bit unsigned value. On MPI shuffles the seed so that different
-/// MPI ranks are seeded with different values.
-///
-/// The optional 2nd argument indicates whether to initialize the RNG on GPU device:
-/// hila::device_rng_on (default) or hila::device_rng_off.  This argument does nothing if not GPU
-/// platform.  If hila::device_rng_off is used, onsites() -loops cannot contain random number calls
-/// (Runtime error will be flagged and program exits).
 
+/**
+ *@brief Seed random generators with 64-bit unsigned value. 
+ *       On MPI shuffles the seed so that different MPI ranks are seeded with different values.
+ */  
 void seed_random(uint64_t seed, bool device_rng = true);
 
-/// @brief Check if RNG is seeded already
+/**
+ *@brief Check if RNG is seeded already
+ */
 bool is_rng_seeded();
 
-///
-/// Initialize host (CPU) random number generator separately, done implicitly by seed_random()
-/// Parameter random number seed.  On MPI shuffles different seed values for all MPI ranks.
-
+/**
+ *@brief Initialize host (CPU) random number generator separately, done implicitly by `seed_random()`
+ */
 void initialize_host_rng(uint64_t seed);
 
-///
-/// Initialize device random number generator on GPUs, if on GPU platform.  No effect on other
-/// archs. On MPI shuffles the seed for different MPI ranks.  Called by seed_random() unless its 2nd
-/// argument is hila::device_rng_off.  This can reinitialize device RNG free'd by free_device_rng().
-
+/**
+ *@brief Initialize device random number generator on GPUs, if application run on GPU platform. 
+ *       No effect on other archs.
+ */
 void initialize_device_rng(uint64_t seed);
 
-///
-/// Free GPU RNG state, hila::random() does not work inside onsites() after this
-/// (unless seeded again using initialize_device_rng()).  Frees the memory RNG takes on the device.
-/// Does nothing on non-GPU archs.
-
+/**
+ *@brief Free GPU RNG state, does nothing on non-GPU archs.
+ */  
 void free_device_rng();
 
 ///
-/// Check if the RNG on GPU is allocated and ready to use.  Returns true on non-GPU archs.
+/// 
 
+/**
+ *@brief Check if the RNG on GPU is allocated and ready to use. 
+ */  
 bool is_device_rng_on();
 
 
@@ -53,11 +51,11 @@ bool is_device_rng_on();
 
 
 /**
- * @brief Real valued uniform random number generator
- * @details Returns a uniform double precision random number in interval [0,1).  Can be
- * called from outside or inside site loops (on GPU if the device rng is initialized).
+ * @brief Real valued uniform random number generator.
+ * @details Returns an uniform double precision random number in interval \f$[0,1)\f$.  
+ * This function can be called from outside or inside site loops (on GPU if the device rng is initialized).
  *
- *  Uses
+ * Uses
  * [std::uniform_real_distribution](https://en.cppreference.com/w/cpp/numeric/random/uniform_real_distribution)
  *
  * @return double
@@ -69,49 +67,45 @@ double random();
 // routine is not normally needed in user code, instead use standard hila::random().
 double host_random();
 
-///
-/// hila::gaussrand() returns a Gaussian distributed random number with variance 1.0, i.e.
-/// the probability distribution is
-///           exp( -x*x/2 ), so < x^2 > = 1
-/// If you want random numbers with variance sigma, multiply the
-/// result by  sqrt(sigma):
-///       sqrt(sigma) * gaussrand();
-
 #pragma hila contains_rng loop_function
+
+/**
+ * @brief Gaussian random generation routine 
+ */  
 double gaussrand();
 
-/// hila::gaussrand2 returns 2 Gaussian distributed random numbers with variance 1.0.
-/// Useful because Box-Muller algorithm computes 2 values at the same time.
 
+/**
+ *@brief `hila::gaussrand2` returns 2 Gaussian distributed random numbers with variance \f$1.0\f$.
+ *@details Useful because Box-Muller algorithm computes 2 values at the same time.
+ */
 #pragma hila contains_rng loop_function
 double gaussrand2(double &out2);
 
-///
-/// do what the name says - program quits with error message if RNG is not initialized and on GPU
-/// archs the device RNG is not initialized.
-
+/**
+ *@brief Check if RNG is initialized, do what the name says.
+ */  
 void check_that_rng_is_initialized();
 
-
-///
-/// Template function
-///     const T & hila::random(T & var)
-/// Sets the argument to a random value, and return a constant reference to it.
-/// Example:
-///     Complex<double> c;
-///     auto n = hila::random(c).abs();
-/// sets the variable c to complex random value and calculates its absolute value.
-/// c.real() and c.imag() will be \in [0,1)
-///
-/// For hila classes relies on the existence of method T::random() (i.e. var.random())
-///
-/// Typically sets the argument real numbers to interval [0,1), but not
-/// always: for example, if T is SU<N,T> -matrix sets the argument to
-/// valid random SU<N,T>.
-///
-/// Advantage over class function T::random() is that the argument can be
-/// of elementary arithmetic type.
-
+/**
+ *@brief Template function `const T & hila::random(T & var)`
+ *       sets the argument to a random value, and return a constant reference to it.
+ *@details For example 
+ *\code{.cpp}
+ *   Complex<double> c;
+ *   auto n = hila::random(c).abs();
+ *\endcode
+ *sets the variable `c` to complex random value and calculates its absolute value.
+ *`c.real()` and `c.imag()` will be \f$\in [0,1)\f$.
+ *
+ *For hila classes relies on the existence of method `T::random()` (i.e. `var.random()`),
+ *this function typically sets the argument real numbers to interval \f$[0,1)\f$ if `type T` is arithmatic.
+ *if T is more commplicated classes such as `SU<N,T>`-matrix, this function sets the argument to
+ * valid random `SU<N,T>`.
+ *
+ * Advantage of this function over class function `T::random()` is that the argument can be
+ * of elementary arithmetic type.
+ */  
 template <typename T, std::enable_if_t<std::is_arithmetic<T>::value, int> = 0>
 T random(out_only T &val) {
     val = hila::random();
@@ -124,63 +118,67 @@ T &random(out_only T &val) {
     return val;
 }
 
-///
-/// Template function
-///     T hila::random<T>();
-/// without argument.  This is used to generate random value for T without defined variable.
-/// Example:
-///     auto n = hila::random<Complex<double>>().abs();
-/// calculates the norm of a random complex value.
-///
-/// hila::random<double>() is functionally equivalent to hila::random()
-
+/**
+ *@brief Template function `T hila::random<T>()` without argument.  
+ *@details This is used to generate random value for `type T` without defined variable.
+ *Example:
+ *\code{.cpp}
+ *    auto n = hila::random<Complex<double>>().abs();
+ *\endcode
+ *  calculates the norm of a random complex value.
+ *`hila::random<double>()` is functionally equivalent to `hila::random()`
+ */
 template <typename T>
 T random() {
     T val;
     hila::random(val);
     return val;
 }
+  
 
-
-///
-/// Template function
-///     const T & hila::gaussian_random(T & variable,double width=1)
-/// Sets the argument to a gaussian random value, and return a constant reference to it.
-/// Optional second argument width sets the variance=width^2 (default=1)
-///
-/// Example:
-///     Complex<double> c;
-///     auto n = sqr(hila::gaussian_random(c));
-/// sets the variable c to complex gaussian random value and stores its square in n.
-///
-/// For hila classes relies on the existence of method T::gaussian_random().
-///
-/// Advantage over class function T::random() is that the argument can be
-/// of elementary arithmetic type.
-
+/**
+ * @brief Template function 
+ *        `const T & hila::gaussian_random(T & variable,double width=1)`
+ * @details Sets the argument to a gaussian random value, and return a constant reference to it.
+ * Optional second argument width sets the \f$variance=width^{2}\f$ (\f$default==1\f$)
+ *
+ * For example:
+ * \code {.cpp}
+ * Complex<double> c;
+ * auto n = sqr(hila::gaussian_random(c));
+ * \endcode
+ * sets the variable `c` to complex gaussian random value and stores its square in `n`.
+ *
+ * This function is for hila classes relies on the existence of method `T::gaussian_random()`.
+ * The advantage for this function over class function `T::random()` is that the argument can be
+ * of elementary arithmetic type.
+ * @return T by reference
+ */    
 template <typename T, std::enable_if_t<std::is_arithmetic<T>::value, int> = 0>
 T gaussian_random(out_only T &val, double w = 1.0) {
     val = hila::gaussrand() * w;
     return val;
 }
-
+  
 template <typename T, std::enable_if_t<!std::is_arithmetic<T>::value, int> = 0>
 T &gaussian_random(out_only T &val, double w = 1.0) {
     val.gaussian_random(w);
     return val;
 }
 
-///
-/// Template function
-///     T hila::gaussian_random<T>();
-/// generates gaussian random value of type T, with variance 1.
-/// Example:
-///     auto n = hila::gaussian_random<Complex<double>>().abs();
-/// calculates the norm of a gaussian random complex value.
-///
-/// Note: there is no width/variance parameter, because of danger of confusion
-/// with above hila::gaussian_random(value)
 
+/**
+ *@brief Template function
+ *       `T hila::gaussian_random<T>()`,generates gaussian random value of `type T`, with variance \f$1\f$.
+ *@details For example,
+ *\code{.cpp}
+ *  auto n = hila::gaussian_random<Complex<double>>().abs();
+ *\endcode
+ *calculates the norm of a gaussian random complex value.
+ *  
+ *@note there is no width/variance parameter, because of danger of confusion
+ *with above `hila::gaussian_random(value)`
+ */  
 template <typename T>
 T gaussian_random() {
     T val;


### PR DESCRIPTION
To master branch: the doxygen documentations of functions in random.h and random.cpp of /libraries/plumbing have been reorganized and re-written in a good-looking way. Especially, demonstration codes and the details descriptions are re-written in proper c++ code formats and Latex formats.

This PR contains all recent commits on documentation branch  from Aaron and me. Before I open this PR, I merged most recent update of upstream documentation branch into my local documentation branch, then merged it into my local master, which also has been update with upstream. 