### PR TITLE
Handle lambda function calls differently for lambdas defined in/outside of 'onsites' loops for GPU code generation.

### DIFF
--- a/hilapp/src/generalvisitor.cpp
+++ b/hilapp/src/generalvisitor.cpp
@@ -608,6 +608,13 @@ var_info *GeneralVisitor::new_var_info(VarDecl *decl) {
     //     vi.type = "element<" + vi.type + ">";
     // llvm::errs() << " + Got " << vi.type << '\n';
 
+    // check if it's a lambda var ref
+    if (Expr *E = vi.decl->getInit()) {
+        if (LambdaExpr *LE = dyn_cast<LambdaExpr>(E)) {
+            vi.is_lambda_var_ref = true;
+        }
+    }
+
     // is it loop-local?
     vi.is_loop_local = false;
     for (var_decl &d : var_decl_list) {
@@ -658,6 +665,12 @@ var_info *GeneralVisitor::add_var_to_decl_list(VarDecl *var, int scope_level) {
     if (var->hasInit()) {
         ip->is_site_dependent = is_site_dependent(var->getInit(), &ip->dependent_vars);
         ip->is_assigned = true;
+        // also check here if it's a lambda function var ref
+        if (Expr *E = var->getInit()) {
+            if (auto LE = dyn_cast<LambdaExpr>(E)) {
+                ip->is_lambda_var_ref = true;
+            }
+        }
     } else {
         ip->is_assigned = false;
     }

--- a/hilapp/src/hilapp.h
+++ b/hilapp/src/hilapp.h
@@ -301,10 +301,11 @@ struct var_info {
     bool is_site_dependent;         // is the value of variable site dependent
     bool is_special_reduction_type; // is variable defined with Reduction<T>
     bool is_raw;                    // is it raw access var?
+    bool is_lambda_var_ref;         // is it a var ref to a lambda function
 
     var_info() {
         is_loop_local = is_assigned = is_site_dependent = is_special_reduction_type = is_raw =
-            false;
+            is_lambda_var_ref = false;
         decl = nullptr;
         reduction_type = reduction::NONE;
     }
@@ -454,8 +455,9 @@ struct call_info_struct {
     bool is_site_dependent;
     bool has_site_dependent_conditional;
     bool contains_random;
-    bool is_defaulted; // We assume that Clang "default" classification functions
-                       // do not need to be handled (incl. default methods)
+    bool is_defaulted;         // We assume that Clang "default" classification functions
+                               // do not need to be handled (incl. default methods)
+    bool is_loop_local_lambda; // if it calls to a lambda function declared inside the loop
 
     call_info_struct() {
         call = nullptr;
@@ -464,7 +466,7 @@ struct call_info_struct {
         ctordecl = nullptr;
         arguments.clear();
         is_method = is_operator = is_site_dependent = contains_random = false;
-        has_site_dependent_conditional = is_defaulted = false;
+        has_site_dependent_conditional = is_defaulted = is_loop_local_lambda = false;
         decl_only = false;
         is_vectorizable = true;
         vector_type_only = number_type::UNKNOWN;

--- a/hilapp/src/loop_function.cpp
+++ b/hilapp/src/loop_function.cpp
@@ -5,6 +5,7 @@
 #include "toplevelvisitor.h"
 #include "hilapp.h"
 #include "stringops.h"
+#include "clang/AST/ASTLambda.h"
 
 // #define LOOP_FUNCTION_DEBUG
 
@@ -67,6 +68,25 @@ void TopLevelVisitor::handle_function_call_in_loop(Stmt *s, bool is_assignment) 
     ci.is_vectorizable = ci.is_vectorizable && vectorizable;
 
     // llvm::errs() << "FUNC " << D->getNameAsString() << " vectorizable " << ci.is_vectorizable << '\n';
+
+    // check if lambda function call:
+    if(CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(D)){
+        if(isLambdaCallOperator(MD)){
+            // CXXRecordDecl *RD = MD->getParent();
+            // check if lambda is defined inside the loop:
+            for(var_decl &vd : var_decl_list){
+                if(vd.scope >= 0 && vd.decl->hasInit()){
+                    if(LambdaExpr *LE = dyn_cast<LambdaExpr>(vd.decl->getInit())){
+                        if(LE->getCallOperator() == MD){
+                            // found local decl for the lambda 
+                            ci.is_loop_local_lambda = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
     /// add to function calls to be checked ...
     loop_function_calls.push_back(ci);

--- a/hilapp/src/sourceloc_utils.cpp
+++ b/hilapp/src/sourceloc_utils.cpp
@@ -69,14 +69,17 @@ SourceLocation findChar(const SourceManager &SM, SourceLocation sloc, char ct) {
 /// If partype == '(', just balance par expressions (may contain strings).
 /// If partype == '<', balance < > -parens (may contain () -parens, which are balanced
 /// in turn) This last one is useful for template scanning
+/// If partype == '[', does the same as for '<'.
 
 SourceLocation skipParens(const SourceManager &SM, SourceLocation sl, const char partype) {
 
-    assert((partype == '(' || partype == '<') && "Unknown paren type in skipParens");
+    assert((partype == '(' || partype == '<' || partype == '[') && "Unknown paren type in skipParens");
 
     char endpar;
     if (partype == '<')
         endpar = '>';
+    else if (partype == '[')
+        endpar = ']';
     else
         endpar = ')';
 


### PR DESCRIPTION
For lambdas defined inside the loops: do nothing.

For lambdas outside of the loops mark lambdas `__device__ __host__` and pass them to the generated kernel as parameters. (nvcc needs --extended-lambda flag.)