### PR TITLE
gradient flow error estimate 

### DIFF
--- a/libraries/gauge/gradient_flow.h
+++ b/libraries/gauge/gradient_flow.h
@@ -280,7 +280,10 @@ atype do_gradient_flow_adapt(GaugeField<group> &V, atype l_start, atype l_end, a
             onsites(ALL) {
                 reldiff[X] = (tk[d][X].squarenorm());
             }
-            maxtk = max(maxtk, reldiff.max());
+            atype tmaxtk = reldiff.max();
+            if(tmaxtk>maxtk) {
+                maxtk = tmaxtk;
+            }
         }
         maxtk = sqrt(0.5 * maxtk);
 
@@ -348,8 +351,8 @@ atype do_gradient_flow_adapt(GaugeField<group> &V, atype l_start, atype l_end, a
         atype maxreldiff = 0.0;
         foralldir(d) {
             onsites(ALL) {
-                reldiff[X] = (V2[d][X] * V[d][X].dagger()).project_to_algebra().max_abs() /
-                             (tatol + rtol * tk[d][X].max_abs());
+                reldiff[X] = (V2[d][X] * V[d][X].dagger()).project_to_algebra().norm() /
+                             (tatol + rtol * tk[d][X].norm());
             }
             atype tmaxreldiff = reldiff.max();
             if (tmaxreldiff > maxreldiff) {
@@ -377,8 +380,8 @@ atype do_gradient_flow_adapt(GaugeField<group> &V, atype l_start, atype l_end, a
 
         // adjust step size :
         step = min((atype)0.9 * maxstep, ubstep);
-        // hila::out0<<"t: "<<t<<" , maxreldiff: "<<maxreldiff<<" , maxstep: "<<maxstep<<" gf ,
-        // step:"<<step<<"\n";
+        //hila::out0<<"t: "<<t<<" , maxreldiff: "<<maxreldiff<<" , maxstep: "
+        //            <<maxstep<<" gf , step:"<<step<<"\n";
     }
 
     return tstep;


### PR DESCRIPTION
Just noticed a mistake in my previous pull request: in the gradient flow function, the difference between RK3 and RK2 should be quantified using norm() and not max_abs(). I had played arround with the latter and then forgot to change it back. I corrected this now. Sorry.