### PR TITLE
Fix infinite loop in srcBuf::replace_tokens…

### DIFF
--- a/hilapp/src/srcbuf.cpp
+++ b/hilapp/src/srcbuf.cpp
@@ -646,13 +646,15 @@ int srcBuf::replace_tokens(int start, int end, const std::vector<std::string> &a
                 }
             }
         } else {
-            if (i > 0 && buf[i] == '/' && buf[i - 1] == '/') {
+            if (i + 1 <= end && buf[i] == '/' && buf[i + 1] == '/') {
                 // skip commented lines
                 for (i++; i <= end && buf[i] != '\n'; i++)
                     ;
-            } else if (i > 0 && buf[i - 1] == '/' && buf[i] == '*') {
-                // c-stype comment
-                i = buf.find("*/", i + 1) + 2;
+            } else if (i + 1 <= end && buf[i] == '/' && buf[i + 1] == '*') {
+                // c-style comment
+                i = buf.find("*/", i + 1);
+                assert(i != std::string::npos && "Did not find '*/'. Unclosed c-style comment."); // TODO: better error message
+                i += 2; // skip over '*/'
             } else if (buf[i] == '#') {
                 // skip preproc lines #
                 for (i++; i <= end && buf[i] != '\n'; i++)


### PR DESCRIPTION
…happening with c-style multiline comments followed by asterisk e.g.  /* */\*  .

This used to go to an infinite loop: 
`$hilapp test.cpp  -I$HILA_DIR/libraries -I$HILA_DIR/libraries/plumbing `
 test.cpp: 
```c++
#include "hila.h"

template<typename T>
void foo(){
    Field<T> a = 0;
    onsites(ALL){
        T b = 123;
        a[X] += 0.5 /* comment */* b;
    }
}

int main(){
    foo<double>();
}
```