### PR TITLE
Wait for comms that are not needed instead of using MPI_Cancel.

### DIFF
--- a/libraries/plumbing/com_mpi.cpp
+++ b/libraries/plumbing/com_mpi.cpp
@@ -16,8 +16,7 @@ hila::timer reduction_timer("MPI reduction");
 hila::timer reduction_wait_timer("MPI reduction wait");
 hila::timer broadcast_timer("MPI broadcast");
 hila::timer send_timer("MPI send field");
-hila::timer cancel_send_timer("MPI cancel send");
-hila::timer cancel_receive_timer("MPI cancel receive");
+hila::timer drop_comms_timer("MPI wait drop_comms");
 hila::timer partition_sync_timer("partition sync");
 
 // let us house the partitions-struct here

--- a/libraries/plumbing/com_mpi.h
+++ b/libraries/plumbing/com_mpi.h
@@ -39,8 +39,7 @@ extern hila::timer
         reduction_wait_timer,
         broadcast_timer,
         send_timer,
-        cancel_send_timer,
-        cancel_receive_timer,
+        drop_comms_timer,
         partition_sync_timer;
 // clang-format on
 

--- a/libraries/plumbing/field.h
+++ b/libraries/plumbing/field.h
@@ -1160,7 +1160,6 @@ class Field {
     void wait_gather(Direction d, Parity p) const;
     void gather(Direction d, Parity p = ALL) const;
     void drop_comms(Direction d, Parity p) const;
-    void cancel_comm(Direction d, Parity p) const;
 
     /**
      * @brief Create a periodically shifted copy of the field
@@ -1903,39 +1902,41 @@ Field<T> Field<T>::shift(const CoordinateVector &v) const {
 
 
 ///  @internal
-///  drop_comms():  if field is changed or deleted,
-///  cancel ongoing communications.  This should happen very seldom,
-///  only if there are "by-hand" start_gather operations and these are not needed
+///  drop_comms(): if field is changed or deleted, 'cancel' ongoing communications. Now just wait
+///  for the communications to finish don't actually cancel them. Still separate this from using
+///  only wait_gather since this needs to be called in ~Field() and we need to check if there are
+///  ongoing communications. User gets nottified if there was redundant communications if
+///  drop_comms_timer is in the run print out.
+///
+///  This should happen very seldom, only if there are "by-hand" start_gather operations and these
+///  are not needed.
 template <typename T>
 void Field<T>::drop_comms(Direction d, Parity p) const {
 
     if (is_comm_initialized()) {
-        if (is_gather_started(d, ALL))
-            cancel_comm(d, ALL);
-        if (p != ALL) {
-            if (is_gather_started(d, p))
-                cancel_comm(d, p);
-        } else {
-            if (is_gather_started(d, EVEN))
-                cancel_comm(d, EVEN);
-            if (is_gather_started(d, ODD))
-                cancel_comm(d, ODD);
+        if (is_gather_started(d, ALL)) {
+            drop_comms_timer.start();
+            wait_gather(d, ALL);
+            drop_comms_timer.stop();
         }
-    }
-}
-
-/// @internal cancel ongoing send and receive
-template <typename T>
-void Field<T>::cancel_comm(Direction d, Parity p) const {
-    if (lattice.nn_comminfo[d].from_node.rank != hila::myrank()) {
-        cancel_receive_timer.start();
-        MPI_Cancel(&fs->receive_request[(int)p - 1][d]);
-        cancel_receive_timer.stop();
-    }
-    if (lattice.nn_comminfo[d].to_node.rank != hila::myrank()) {
-        cancel_send_timer.start();
-        MPI_Cancel(&fs->send_request[(int)p - 1][d]);
-        cancel_send_timer.stop();
+        if (p != ALL) {
+            if (is_gather_started(d, p)) {
+                drop_comms_timer.start();
+                wait_gather(d, p);
+                drop_comms_timer.stop();
+            }
+        } else {
+            if (is_gather_started(d, EVEN)) {
+                drop_comms_timer.start();
+                wait_gather(d, EVEN);
+                drop_comms_timer.stop();
+            }
+            if (is_gather_started(d, ODD)) {
+                drop_comms_timer.start();
+                wait_gather(d, ODD);
+                drop_comms_timer.stop();
+            }
+        }
     }
 }
 

--- a/libraries/plumbing/hilapp_mpi.h
+++ b/libraries/plumbing/hilapp_mpi.h
@@ -36,12 +36,15 @@ enum MPI_Op : int { MPI_SUM, MPI_PROD, MPI_MAX, MPI_MIN, MPI_MAXLOC, MPI_MINLOC 
 
 typedef void *MPI_Comm;
 typedef void *MPI_Request;
-typedef int MPI_Status;
+typedef struct ompi_status_public_t MPI_Status;
 typedef void *MPI_Comm;
 typedef int MPI_Fint;
+typedef void *MPI_Errhandler;
 #define MPI_IN_PLACE nullptr
 #define MPI_COMM_WORLD nullptr
 #define MPI_STATUS_IGNORE nullptr
+#define MPI_ERRORS_RETURN nullptr
+#define MPI_REQUEST_NULL nullptr
 #define MPI_SUCCESS 1
 
 enum MPI_thread_level : int {
@@ -51,6 +54,19 @@ enum MPI_thread_level : int {
     MPI_THREAD_MULTIPLE
 };
 
+struct ompi_status_public_t {
+    /* These fields are publicly defined in the MPI specification.
+       User applications may freely read from these fields. */
+    int MPI_SOURCE;
+    int MPI_TAG;
+    int MPI_ERROR;
+    /* The following two fields are internal to the Open MPI
+       implementation and should not be accessed by MPI applications.
+       They are subject to change at any time.  These are not the
+       droids you're looking for. */
+    int _cancelled;
+    size_t _ucount;
+};
 
 int MPI_Init(int *argc, char ***argv);
 
@@ -61,6 +77,8 @@ int MPI_Comm_rank(MPI_Comm comm, int *rank);
 int MPI_Comm_size(MPI_Comm comm, int *size);
 
 int MPI_Comm_split(MPI_Comm comm, int color, int key, MPI_Comm *newcomm);
+
+int MPI_Comm_set_errhandler(MPI_Comm comm, MPI_Errhandler errhandler);
 
 int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype, int root, MPI_Comm comm);
 
@@ -98,6 +116,12 @@ int MPI_Barrier(MPI_Comm comm);
 int MPI_Ibarrier(MPI_Comm comm, MPI_Request *request);
 
 int MPI_Cancel(MPI_Request *request);
+
+int MPI_Test(MPI_Request *request, int *flag, MPI_Status *status);
+
+int MPI_Test_cancelled(const MPI_Status *status, int *flag);
+
+int MPI_Request_free(MPI_Request *request);
 
 int MPI_Abort(MPI_Comm comm, int errorcode);
 


### PR DESCRIPTION
Previous way of using MPI_Cancel to cancel not needed communications could result into some of the IRecv being cancelled but some of the ISends to not be cancelled. This then could result into the following IRecv receiving the wrong message (if the message tags wrap around just right). If the field types were different between send/recv this resulted into a MPI_ERR_TRUNCATE. Even worse is if the field types happened to be the same the following receive would get just wrong data.