### PR TITLE
Add block_(gauge_)to_current_lattice methods. Blocks a field defined …

### DIFF
--- a/libraries/plumbing/field.h
+++ b/libraries/plumbing/field.h
@@ -1582,6 +1582,14 @@ class Field {
      */
     void block_from(Field<T> &orig);
 
+
+    /**
+     * @brief Block the Field to the currently active lattice
+     * @details This Field has to be defined on the current active lattice's parent lattice. Useful
+     * when blocking in a loop.
+     */
+    void block_to_current_lattice();
+
     /**
      * @brief Copy content to the argument Field on blocked (sparse) sites.
      * a.unblock_to(b) is the inverse of a.block_from(b)


### PR DESCRIPTION
…on the current lattices parent to the current active lattice (seemingly) in place.
These methods are convenient when blocking the lattice in a loop. (TODO: can still be optimized further.)

Without these the intuitive thing to do:
```c++
    GaugeField<group> U;
    GaugeField<group> b_U, b_U2;
    b_U2 = U; // alloc & cpy
    while ( lattice.can_block({2,2,2}) ){
        lattice.block({2,2,2});
        b_U.block_gauge(b_U2); // alloc & cpy

        // compute stuff

        foralldir(d){ b_U2[d].clear(); } // free
        b_U2 = b_U;                      // alloc & cpy
        foralldir(d){ b_U[d].clear(); }  // free
    }
```

With you can do:
```c++
    GaugeField<group> U;
    GaugeField<group> b_cU;
    b_cU = U; // alloc & cpy
    while ( lattice.can_block({2,2,2}) ){
        lattice.block({2,2,2});
        b_cU.block_gauge_to_current_lattice(); // alloc & cpy & free

        // compute stuff
    }
```