### PR TITLE
Add move constructor and move assignment for GaugeField.

### DIFF
--- a/libraries/plumbing/gaugefield.h
+++ b/libraries/plumbing/gaugefield.h
@@ -88,6 +88,23 @@ class GaugeField {
         return *this;
     }
 
+    // This is now explicitly needed since it is implicitly deleted when move constructor is defined
+    GaugeField &operator=(const GaugeField &rhs) {
+        foralldir(d) fdir[d] = rhs[d];
+        return *this;
+    }
+
+    GaugeField(GaugeField &&rhs) {
+        foralldir(d)(*this)[d] = std::move(rhs[d]);
+    }
+
+    GaugeField &operator=(GaugeField &&rhs) {
+        if (this != &rhs) {
+            foralldir(d)(*this)[d] = std::move(rhs[d]);
+        }
+        return *this;
+    }
+
     void clear() {
         foralldir(d) fdir[d].clear();
     }


### PR DESCRIPTION
To make std::move and std::swap for GaugeFields do the most optimal thing you expect, so 'swap pointers around' not to make temp fields and copy.

e.g. std::swap(U2, U)
Without move assignment equivalent to:
```c++
     {
        GaugeField<SU2<double>> tmp;
        foralldir(i) onsites(ALL) tmp[i][X] = U[i][X]
        foralldir(i) onsites(ALL) U[i][X] = U2[i][X]
        foralldir(i) onsites(ALL) U2[i][X] = tmp[i][X]
    }
```
With it, it just swaps the field_struct's.