### PR TITLE
make GIT_SHA_FILE depend on the LASTMAKE to prevent a 'race condition…

### DIFF
--- a/libraries/main.mk
+++ b/libraries/main.mk
@@ -183,7 +183,7 @@ GIT_SHA_FILE := build/.git_sha_number_$(GIT_SHA)
 
 # Force recompilation if git number has changed
 
-$(GIT_SHA_FILE):
+$(GIT_SHA_FILE): $(LASTMAKE)
 	-rm -f build/.git_sha_number_*
 	touch $(GIT_SHA_FILE)
 


### PR DESCRIPTION
…' with it which results into make building everything needlesly again even if nothing is changed (since it runs make clean, it may remove the just created GIT_SHA_FILE on a fresh build done with multiple jobs -jN)